### PR TITLE
- fix: undefined server fetchOneAsync named query

### DIFF
--- a/lib/namedQuery/namedQuery.server.js
+++ b/lib/namedQuery/namedQuery.server.js
@@ -57,12 +57,25 @@ export default class extends Base {
   }
 
   /**
-   * @param args
+   * @param {Grapher.QueryFetchContext<T>} [context]
    * @returns {*}
+   * @deprecated
+   * @see fetchOneAsync
    */
-  fetchOne(...args) {
-    return _.first(this.fetch(...args));
+  fetchOne(context) {
+    throw new Error('fetchOne is not available on server, please use fetchOneAsync');
   }
+
+  /**
+   * Fetches one element in async
+   * @param {Grapher.QueryFetchContext<T>} [context]
+   * @returns {Promise<T | undefined>}
+   */
+  async fetchOneAsync(context) {
+    return _.first(await this.fetchAsync(context));
+  }
+
+
 
   /**
    * Gets the count of matching elements.

--- a/lib/namedQuery/testing/server.test.js
+++ b/lib/namedQuery/testing/server.test.js
@@ -37,6 +37,19 @@ describe('Named Query', function () {
     }
   });
 
+  it('Should return a single result with fetchOneAsync', async function () {
+    const query = postList.clone({
+      title: 'User Post - 3',
+    });
+
+    const post = await query.fetchOneAsync();
+
+    assert.isObject(post);
+    assert.equal(post.title, 'User Post - 3');
+    assert.isObject(post.author);
+    assert.isObject(post.group);
+  });
+
   it('Exposure embodyment should work properly', async function () {
     const query = createQuery({
       postListExposure: {


### PR DESCRIPTION
This PR fixes an issue where fetchOneAsync was not defined in server-side named queries and adds a corresponding test to ensure its functionality.